### PR TITLE
Add NTEE Org filter to map home page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -78,6 +78,7 @@
         <script src="scripts/map/cartodb-vis-directive.js"></script>
         <script src="scripts/map/map-style-service.js"></script>
         <script src="scripts/map/area-analysis-control-directive.js"></script>
+        <script src="scripts/map/filter-control-directive.js"></script>
         <script src="scripts/brand/module.js"></script>
         <script src="scripts/brand/brand-directive.js"></script>
         <script src="scripts/geo/module.js"></script>

--- a/app/scripts/map/cartodb-vis-directive.js
+++ b/app/scripts/map/cartodb-vis-directive.js
@@ -34,6 +34,7 @@
         function initialize() {
             ctl.demographics = !!($scope.$eval($attrs.demographics));
             ctl.drawControl = !!($scope.$eval($attrs.drawControl));
+            ctl.filterControl = !!($scope.$eval($attrs.filterControl));
             ctl.visFullscreenClass = $attrs.visFullscreenClass || 'map-expanded';
             ctl.sublayers = [];
             ctl.radio = '-1';
@@ -165,6 +166,8 @@
                 // demographics: bool, should the demographics layers be shown on the map
                 //                     default: false
                 // drawControl: bool, should the area analysis draw control be shown on the map
+                //                     default: false
+                // filterControl: bool, should the vis filter control be shown on the map
                 //                     default: false
             },
             templateUrl: 'scripts/map/cartodb-vis-partial.html',

--- a/app/scripts/map/cartodb-vis-partial.html
+++ b/app/scripts/map/cartodb-vis-partial.html
@@ -31,6 +31,7 @@
         </div>
     </div>
     <div area-analysis-control class="vis-draw-control" ng-if="vis.drawControl"></div>
+    <div viz-filter-control class="vis-filter-control" ng-if="vis.filterControl"></div>
     <div id="map"></div>
     <div class="cartodb-fullscreen"><a ng-click="vis.onFullscreenClicked()"></a></div>
 </div> <!-- /.map-container -->

--- a/app/scripts/map/filter-control-directive.js
+++ b/app/scripts/map/filter-control-directive.js
@@ -25,7 +25,7 @@
     function FilterController($scope, Config) {
         var layer = null;
         var filterColumn = 'ntee_org_type_new';
-        var noneName = 'None';
+        var noneName = 'All';
         var noneValue = {name: noneName, value: null};
         var table = Config.cartodb.tableName;
 

--- a/app/scripts/map/filter-control-directive.js
+++ b/app/scripts/map/filter-control-directive.js
@@ -1,21 +1,5 @@
 /**
- * Control to allow the user to select or draw custom ACS analysis areas on the cartodb-vis map
- *
- * Events:
- * imls:area-analysis-control:radius:changed Triggered when the radius is changed in the
- *                                           control select dropdown
- *     {Number} radius The radius selected in meters
- *
- * imls:area-analysis-control:draw:start Triggered when the user clicks on any of the custom
- *                                       draw buttons
- *     {String} drawType The button selected, currently one of 'circle'|'polygon'
- *
- * imls:area-analysis-control:draw:complete Triggered when the user finishes drawing a custom shape
- *     {Event} drawEvent The event fired by the L.Draw control, passed through
- *
- * imls:area-analysis-control:draw:cancel Listened for on scope, trigger elsewhere to clear the
- *                                        draw handler and reset the control
- *
+ * Control to allow the user to filter by the categories displayed on the cartodb-vis map
  */
 
 (function () {

--- a/app/scripts/map/filter-control-directive.js
+++ b/app/scripts/map/filter-control-directive.js
@@ -33,7 +33,7 @@
         initialize();
 
         function initialize() {
-            var options = Config.cartodb.legend.data;
+            var options = _.cloneDeep(Config.cartodb.legend.data);
             options.splice(0, 0, noneValue);
             ctl.options = options;
             ctl.filterValue = noneValue;

--- a/app/scripts/map/filter-control-directive.js
+++ b/app/scripts/map/filter-control-directive.js
@@ -1,0 +1,84 @@
+/**
+ * Control to allow the user to select or draw custom ACS analysis areas on the cartodb-vis map
+ *
+ * Events:
+ * imls:area-analysis-control:radius:changed Triggered when the radius is changed in the
+ *                                           control select dropdown
+ *     {Number} radius The radius selected in meters
+ *
+ * imls:area-analysis-control:draw:start Triggered when the user clicks on any of the custom
+ *                                       draw buttons
+ *     {String} drawType The button selected, currently one of 'circle'|'polygon'
+ *
+ * imls:area-analysis-control:draw:complete Triggered when the user finishes drawing a custom shape
+ *     {Event} drawEvent The event fired by the L.Draw control, passed through
+ *
+ * imls:area-analysis-control:draw:cancel Listened for on scope, trigger elsewhere to clear the
+ *                                        draw handler and reset the control
+ *
+ */
+
+(function () {
+    'use strict';
+
+    /** @ngInject */
+    function FilterController($scope, Config) {
+        var layer = null;
+        var filterColumn = 'ntee_org_type_new';
+        var noneName = 'None';
+        var noneValue = {name: noneName, value: null};
+        var table = Config.cartodb.tableName;
+
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            var options = Config.cartodb.legend.data;
+            options.splice(0, 0, noneValue);
+            ctl.options = options;
+            ctl.filterValue = noneValue;
+
+            ctl.onFilterOptionChanged = onFilterOptionChanged;
+
+            $scope.$on('imls:vis:ready', function (event, viz) {
+                layer = viz.getLayers()[1];
+            });
+        }
+
+        function vizSqlForValue(value) {
+            if (value === noneName) {
+                return 'SELECT * FROM ' + table;
+            } else {
+                return 'SELECT * FROM ' + table + ' ' +
+                    'WHERE ' + filterColumn + '=\'' + value + '\'';
+            }
+        }
+
+        function onFilterOptionChanged() {
+            setFilterValue(ctl.filterValue.name);
+        }
+
+        function setFilterValue(value) {
+            var sql = vizSqlForValue(value);
+            layer.setQuery(sql);
+        }
+    }
+
+    /** @ngInject */
+    function filterControl() {
+        var module = {
+            restrict: 'A',
+            templateUrl: 'scripts/map/filter-control-partial.html',
+            scope: true,
+            controller: 'FilterController',
+            controllerAs: 'fc',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('imls.map')
+    .controller('FilterController', FilterController)
+    .directive('vizFilterControl', filterControl);
+
+})();

--- a/app/scripts/map/filter-control-partial.html
+++ b/app/scripts/map/filter-control-partial.html
@@ -1,4 +1,4 @@
-<p>NTEE Org Type:</p>
+<p>Organization Type:</p>
 <select
     ng-change="fc.onFilterOptionChanged()"
     ng-model="fc.filterValue"

--- a/app/scripts/map/filter-control-partial.html
+++ b/app/scripts/map/filter-control-partial.html
@@ -1,0 +1,6 @@
+<span>NTEE Org Type:</span>
+<select
+    ng-change="fc.onFilterOptionChanged()"
+    ng-model="fc.filterValue"
+    ng-options="item as item.name for item in fc.options track by item.name">
+</select>

--- a/app/scripts/map/filter-control-partial.html
+++ b/app/scripts/map/filter-control-partial.html
@@ -1,4 +1,4 @@
-<span>NTEE Org Type:</span>
+<p>NTEE Org Type:</p>
 <select
     ng-change="fc.onFilterOptionChanged()"
     ng-model="fc.filterValue"

--- a/app/scripts/views/home/home-partial.html
+++ b/app/scripts/views/home/home-partial.html
@@ -43,7 +43,7 @@
         </div>
     </div>
 
-    <cartodb-vis vis-fullscreen="home.mapExpanded"></cartodb-vis>
+    <cartodb-vis filter-control="true" vis-fullscreen="home.mapExpanded"></cartodb-vis>
 
     <ui-view></ui-view>
 

--- a/app/scripts/views/museum/museum-partial.html
+++ b/app/scripts/views/museum/museum-partial.html
@@ -14,6 +14,7 @@
         </div>
     </div>
     <cartodb-vis draw-control="true"
+                 filter-control="true"
                  vis-fullscreen="museum.mapExpanded"
                  vis-fullscreen-on-toggle="museum.onMapExpanded"></cartodb-vis>
 

--- a/app/styles/components/_map-tools.scss
+++ b/app/styles/components/_map-tools.scss
@@ -38,7 +38,8 @@
     }
 
     .vis-layer-selector,
-    .vis-draw-control {
+    .vis-draw-control,
+    .vis-filter-control {
         padding: 10px;
         position: absolute;
         bottom: 20px;

--- a/app/styles/components/_map-tools.scss
+++ b/app/styles/components/_map-tools.scss
@@ -38,12 +38,25 @@
     }
 
     .vis-layer-selector,
+    .vis-draw-control {
+        bottom: 20px;
+        right: 20px;
+    }
+
+    .vis-filter-control {
+        bottom: 20px;
+        left: 20px;
+    }
+
+    .cartodb-legend {
+        bottom: 120px !important;
+    }
+
+    .vis-layer-selector,
     .vis-draw-control,
     .vis-filter-control {
         padding: 10px;
         position: absolute;
-        bottom: 20px;
-        right: 20px;
         font-size: 13px;
         -webkit-box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
         -moz-box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;


### PR DESCRIPTION
## Overview

Adds filter control to map home page that allows user to filter map by org type.

## Demo

_Updated 11/8/2017:_

<img width="1278" alt="screen shot 2017-11-08 at 14 48 42" src="https://user-images.githubusercontent.com/1818302/32570982-f318c2d6-c493-11e7-86a4-d3918ea491c1.png">
<img width="1279" alt="screen shot 2017-11-08 at 14 47 48" src="https://user-images.githubusercontent.com/1818302/32570983-f52d4042-c493-11e7-9636-6e3cd36f857a.png">


## Notes

~~Pending clarification on whether this should also be added to the detail view~~This was requested, PR updated.

## Testing

Filter some stuff on the home page map.

Closes #9 