### PR TITLE
Update search to suggest only address and zip

### DIFF
--- a/app/scripts/config.js.example
+++ b/app/scripts/config.js.example
@@ -13,11 +13,11 @@
         bounds: {
             northEast: {
                 lat: 40.137992,
-                lng: -75.280266
+                lng: -74.955763
             },
             southWest: {
                 lat: 39.867004,
-                lng: -74.955763
+                lng: -75.280266
             }
         },
         detailZoom: 14,

--- a/app/scripts/geocoder/geocoder-service.js
+++ b/app/scripts/geocoder/geocoder-service.js
@@ -70,12 +70,11 @@
             options = options || {};
             var defaults = {
                 singleLine: text,
-                bbox: boundingBox,
+                searchExtent: boundingBox,
                 outFields: outFields,
                 category: searchCategories,
                 maxLocations: maxResults,
                 sourceCountry: sourceCountry,
-                region: 'Pennsylvania',
                 f: 'pjson'
             };
             var params = angular.extend({}, defaults, options);

--- a/app/scripts/views/home/home-partial.html
+++ b/app/scripts/views/home/home-partial.html
@@ -19,7 +19,7 @@
                                 <i class="preloader small" ng-if="home.loadingSearch"></i>
                             </label>
                             <input type="text"
-                                   placeholder="Search by museum, city or zip"
+                                   placeholder="Search by org, address or zip"
                                    class="form-control search-field"
                                    ng-model="home.searchText"
                                    uib-typeahead="location as location.name for location in home.search($viewValue)"


### PR DESCRIPTION
## Overview

Since all results are within the city of Philadelphia. Search results are for the zip of the searched address.

## Demo

![screen shot 2017-11-03 at 15 42 41](https://user-images.githubusercontent.com/1818302/32392943-0799daea-c0ae-11e7-997d-c8fff0d6195d.png)
![screen shot 2017-11-03 at 15 42 55](https://user-images.githubusercontent.com/1818302/32392948-0ae2ef7a-c0ae-11e7-9c8d-452b8696aacd.png)
![screen shot 2017-11-03 at 15 43 01](https://user-images.githubusercontent.com/1818302/32392954-0d169cce-c0ae-11e7-993b-eb388e265ee1.png)


## Notes

Fixes a swap in the default config bounding box extent that prevented bbox geocoding from working properly

## Testing

Update the bounding box extent in your config.js

Search a few addresses/zips, make sure results are sensible.

Closes #14 