### PR TITLE
Truncated Mission statements

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -113,6 +113,7 @@
         <script src="scripts/views/download/download-controller.js"></script>
         <script src="scripts/views/museum/module.js"></script>
         <script src="scripts/views/museum/museum-controller.js"></script>
+        <script src="scripts/views/museum/mission-directive.js"></script>
         <script src="scripts/views/museum/social-links-directive.js"></script>
         <script src="scripts/views/museum/tab-people-directive.js"></script>
         <script src="scripts/views/museum/tab-households-directive.js"></script>

--- a/app/scripts/views/museum/mission-directive.js
+++ b/app/scripts/views/museum/mission-directive.js
@@ -1,0 +1,39 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function MissionController() {
+        // Approx three lines of text in detail view
+        var SHORT_CHAR_LIMIT = 350;
+        var ctl = this;
+        ctl.expanded = false;
+        ctl.$onChanges = $onChanges;
+
+        function $onChanges(changes) {
+            var mission = changes.mission.currentValue;
+            if (mission) {
+                ctl.shortMission = mission.substring(0, SHORT_CHAR_LIMIT);
+            }
+        }
+    }
+
+    /* ngInject */
+    function mission() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/museum/mission-partial.html',
+            controller: 'MissionController',
+            controllerAs: 'ivm',
+            scope: {
+                mission: '<'
+            },
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('imls.views.museum')
+    .controller('MissionController', MissionController)
+    .directive('imlsMission', mission);
+
+})();

--- a/app/scripts/views/museum/mission-directive.js
+++ b/app/scripts/views/museum/mission-directive.js
@@ -7,12 +7,17 @@
         var SHORT_CHAR_LIMIT = 350;
         var ctl = this;
         ctl.expanded = false;
+        ctl.showMore = false;
         ctl.$onChanges = $onChanges;
 
         function $onChanges(changes) {
             var mission = changes.mission.currentValue;
-            if (mission) {
+            if (mission && mission.length) {
                 ctl.shortMission = mission.substring(0, SHORT_CHAR_LIMIT);
+                ctl.showMore = !(mission.length === ctl.shortMission.length);
+                if (ctl.showMore) {
+                    ctl.shortMission = ctl.shortMission + '...';
+                }
             }
         }
     }

--- a/app/scripts/views/museum/mission-partial.html
+++ b/app/scripts/views/museum/mission-partial.html
@@ -1,2 +1,2 @@
-<p ng-if="ivm.expanded">{{ ivm.mission }} <a ng-click="ivm.expanded = !ivm.expanded">Less</a></p>
-<p ng-if="!ivm.expanded">{{ ivm.shortMission }}... <a ng-click="ivm.expanded = !ivm.expanded">More</a></p>
+<p ng-if="ivm.mission.length && ivm.expanded">{{ ivm.mission }} <a ng-click="ivm.expanded = !ivm.expanded">Less</a></p>
+<p ng-if="ivm.mission.length && !ivm.expanded">{{ ivm.shortMission }} <a ng-if="ivm.showMore" ng-click="ivm.expanded = !ivm.expanded">More</a></p>

--- a/app/scripts/views/museum/mission-partial.html
+++ b/app/scripts/views/museum/mission-partial.html
@@ -1,0 +1,2 @@
+<p ng-if="ivm.expanded">{{ ivm.mission }} <a ng-click="ivm.expanded = !ivm.expanded">Less</a></p>
+<p ng-if="!ivm.expanded">{{ ivm.shortMission }}... <a ng-click="ivm.expanded = !ivm.expanded">More</a></p>

--- a/app/scripts/views/museum/museum-partial.html
+++ b/app/scripts/views/museum/museum-partial.html
@@ -25,7 +25,7 @@
                         <a class="back-to-results" ng-click="museum.onBackButtonClicked()"><i class="md-icon-left-big"></i></a>
                         <h1>{{ ::museum.museum.organization_new }} </h1>
                         <h5>{{ ::museum.museum | imlsAddress }}</h5>
-                        <p ng-if="museum.museum.org_miission_new">{{ ::museum.museum.org_miission_new }}</p>
+                        <imls-mission mission="museum.museum.org_miission_new"></imls-mission>
                         <imls-social-links museum="museum.museum"></imls-social-links>
                     </div>
                 </div>


### PR DESCRIPTION
## Overview

Shortens long mission statements so they don't overrun by default. Use can still click "More"/"Less" buttons to view the whole mission statement if its too long.

## Demo

**No Mission:**
![screen shot 2017-11-06 at 10 33 37](https://user-images.githubusercontent.com/1818302/32448861-15dcce32-c2de-11e7-8a02-2c1926d8a270.png)

**Short Mission:**
![screen shot 2017-11-06 at 10 34 04](https://user-images.githubusercontent.com/1818302/32448870-1ceb5770-c2de-11e7-86a6-5a7babbde04c.png)

**Long Mission:**
![screen shot 2017-11-06 at 10 34 13](https://user-images.githubusercontent.com/1818302/32448886-24a74e60-c2de-11e7-8492-ec26e518e098.png)
![screen shot 2017-11-06 at 10 34 18](https://user-images.githubusercontent.com/1818302/32448893-262ce650-c2de-11e7-9786-3c7769dbde24.png)


## Testing

- Long mission: http://localhost:9900/#/museum/222837686/
- Short mission: http://localhost:9900/#/museum/231365343/
- No mission: http://localhost:9900/#/museum/473729424/