### PR TITLE
Implement custom popups and hover interactivity on carto map

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -79,6 +79,7 @@
         <script src="scripts/map/map-style-service.js"></script>
         <script src="scripts/map/area-analysis-control-directive.js"></script>
         <script src="scripts/map/filter-control-directive.js"></script>
+        <script src="scripts/map/org-count-service.js"></script>
         <script src="scripts/brand/module.js"></script>
         <script src="scripts/brand/brand-directive.js"></script>
         <script src="scripts/geo/module.js"></script>

--- a/app/scripts/map/cartodb-vis-partial.html
+++ b/app/scripts/map/cartodb-vis-partial.html
@@ -32,6 +32,7 @@
     </div>
     <div area-analysis-control class="vis-draw-control" ng-if="vis.drawControl"></div>
     <div viz-filter-control class="vis-filter-control" ng-if="vis.filterControl"></div>
+    <div id="vis-popover"></div>
     <div id="map"></div>
     <div class="cartodb-fullscreen"><a ng-click="vis.onFullscreenClicked()"></a></div>
 </div> <!-- /.map-container -->

--- a/app/scripts/map/org-count-service.js
+++ b/app/scripts/map/org-count-service.js
@@ -1,0 +1,44 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function OrgCount($q, Config) {
+
+        var countData = {};
+        getCounts();
+
+        var module = {
+            atLatLng: atLatLng
+        };
+        return module;
+
+        function atLatLng(latitude, longitude) {
+            var key = makeKey(latitude, longitude);
+            // Assume only one point at location if no result for the requested lat/lng combination
+            return countData[key] || 1;
+        }
+
+        function makeKey(latitude, longitude) {
+            return latitude.toString() + ',' + longitude.toString();
+        }
+
+        function getCounts() {
+            var client = new cartodb.SQL({user: Config.cartodb.account});
+            var sql = 'select latitude, longitude, count(*) as num_results ' +
+                'FROM {{ table }} WHERE latitude is not null AND longitude is not null ' +
+                'GROUP BY latitude, longitude';
+            client.execute(sql, {table: Config.cartodb.tableName}).done(function (data) {
+                _.forEach(data.rows, function (d) {
+                    var key = makeKey(d.latitude, d.longitude);
+                    /* jshint camelcase:false */
+                    countData[key] = d.num_results;
+                    /* jshint camelcase:true */
+                });
+            });
+        }
+    }
+
+    angular.module('imls.map')
+    .service('OrgCountService', OrgCount);
+
+})();

--- a/app/scripts/views/museum/mission-directive.js
+++ b/app/scripts/views/museum/mission-directive.js
@@ -14,7 +14,7 @@
             var mission = changes.mission.currentValue;
             if (mission && mission.length) {
                 ctl.shortMission = mission.substring(0, SHORT_CHAR_LIMIT);
-                ctl.showMore = !(mission.length === ctl.shortMission.length);
+                ctl.showMore = mission.length !== ctl.shortMission.length;
                 if (ctl.showMore) {
                     ctl.shortMission = ctl.shortMission + '...';
                 }

--- a/app/styles/components/_map-tools.scss
+++ b/app/styles/components/_map-tools.scss
@@ -95,6 +95,17 @@
             display: none;
         }
     }
+
+    #vis-popover {
+        display: none;
+        position: absolute;
+        background: #fff;
+        z-index: 1000;
+
+        &.visible {
+            display: block;
+        }
+    }
 }
 
 .leaflet-bar {
@@ -153,6 +164,36 @@
 
         p {
             color: $white;
+        }
+    }
+
+    // new click popup
+    .popup {
+        .popup-content {
+            max-height: 250px;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+
+            & > .popup-content-row {
+                width: 100%;
+                display: flex;
+                align-items: center;
+
+                .org-type {
+                    height: 1em;
+                    width: 1em;
+                    border: solid 1px black;
+                }
+
+                span {
+                    display: inline-block;
+                }
+
+                a {
+                    margin-left: 20px;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

Custom interactivity requested to handle cases where there is more than one location at a particular location. This commonly happens with this dataset when geocoded addresses have PO Boxes or other non-specific addresses.

## Demo

#### Hover over point with only one org
![screen shot 2017-11-13 at 15 11 58](https://user-images.githubusercontent.com/1818302/32747141-d1a1ebf0-c885-11e7-94fe-bb9c5dcf7320.png)

#### Popup over point with single org
![screen shot 2017-11-13 at 15 16 10](https://user-images.githubusercontent.com/1818302/32747087-b34c4c36-c885-11e7-92b4-0d41eae275c2.png)

#### Hover over point with multiple orgs
![screen shot 2017-11-13 at 15 13 48](https://user-images.githubusercontent.com/1818302/32747098-bb8e475a-c885-11e7-85b4-eccb7dbece8a.png)

#### Popup over point with multiple orgs
![screen shot 2017-11-13 at 15 12 25](https://user-images.githubusercontent.com/1818302/32747115-c3a3fc0a-c885-11e7-8bc5-1f1ab3e6527d.png)



## Notes 

This particular implementation follows from a discussion with @jcahail about the expected features, balanced against what we can actually accomplish with carto. The major limiting factor is that the events that we use to handle the interactivity only ever respond with the cartodb_id for a single row at a point. So we have to query to know whether there are additional locations there. This prevents us from including a ton of info on the hover unless we pulled most of the dataset into memory on page load. Instead we settle for just getting the counts of orgs at a point. We're open to other implementations and/or tweaking the popups/popovers here if the result doesn't require additional complexity.

Mention to @designmatty so you can see the implementation. Added mostly blank and unstyled hooks in the _map-tools.scss file and the templates are at the top of cartodb-vis-directive.js.

Closes #7, Closes #8 