### PR TITLE
Re-add Demographics Layers

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -79,6 +79,7 @@
         <script src="scripts/map/map-style-service.js"></script>
         <script src="scripts/map/area-analysis-control-directive.js"></script>
         <script src="scripts/map/filter-control-directive.js"></script>
+        <script src="scripts/map/demographics-config.js"></script>
         <script src="scripts/map/org-count-service.js"></script>
         <script src="scripts/brand/module.js"></script>
         <script src="scripts/brand/brand-directive.js"></script>

--- a/app/scripts/config.js.example
+++ b/app/scripts/config.js.example
@@ -26,7 +26,7 @@
             tableName: 'impactviewphilly_102617',
             tractsTableName: 'philly_census_tracts_2010',
             demographicVisUrl: 'https://npecosystem.carto.com/api/v2/viz/dfa88f97-3a97-4ac5-838c-337fb912f29e/viz.json',
-            demographicVisColumns: 'cartodb_id, median_income, poverty_rate',
+            demographicVisColumns: 'cartodb_id, median_income, poverty_rate, percent_under18_percentage, percent_pop_without_hs_diploma',
             // This object should conform to the config object passed to
             //   cdb.geo.ui.Legend.Category
             // demonstrated here: https://gist.github.com/javisantana/6410678#file-index-html-L54-L61
@@ -34,6 +34,8 @@
             //   should also be updated
             legend: {
                 title: 'Organizations by Type',
+                show_title: true,
+                type: 'category',
                 data: [
                     { name: 'Human Services', value: '#5F4690'},
                     { name: 'Education', value: '#1D6996'},

--- a/app/scripts/map/area-analysis-control-partial.html
+++ b/app/scripts/map/area-analysis-control-partial.html
@@ -1,37 +1,43 @@
-<p>Analysis Area: {{ aac.area }} sq. miles</p>
-<form class="form-inline">
-    <div class="action-group">
-        <div class="form-group">
-            <select ng-model="aac.acsRadius"
-                    ng-change="aac._onRadiusChanged()"
-                    ng-options="opt.value as opt.label for opt in aac.acsRadiusOptions"
-                    class="form-control">
-            </select>
-        </div>
+<div class="vis-control vis-draw-control" ng-class="{'visible': aac.open}">
+    <div class="vis-control-button" ng-click="aac.open = !aac.open">
+        <i class="md-icon-polygon-draw"></i><span ng-show="aac.open">Analysis Area: {{ aac.area }} sq. miles</span>
     </div>
+    <div class="vis-control-body" ng-show="aac.open">
+        <form class="form-inline">
+            <div class="action-group">
+                <div class="form-group">
+                    <select ng-model="aac.acsRadius"
+                            ng-change="aac._onRadiusChanged()"
+                            ng-options="opt.value as opt.label for opt in aac.acsRadiusOptions"
+                            class="form-control">
+                    </select>
+                </div>
+            </div>
 
-    <div class="action-group">
-        <div class="form-group">
-            <button type="button"
-                    class="form-control mapExpand"
-                    data-toggle="tooltip"
-                    data-placement="bottom"
-                    ng-click="aac.onStartDrawPolygon()"
-                    title="Draw custom area">
-                <i class="md-icon-polygon-draw"></i>
-            </button>
-        </div>
+            <div class="action-group">
+                <div class="form-group">
+                    <button type="button"
+                            class="form-control mapExpand"
+                            data-toggle="tooltip"
+                            data-placement="bottom"
+                            ng-click="aac.onStartDrawPolygon()"
+                            title="Draw custom area">
+                        <i class="md-icon-polygon-draw"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="action-group">
+                <div class="form-group">
+                    <button type="button"
+                            class="form-control mapExpand"
+                            data-toggle="tooltip"
+                            data-placement="bottom"
+                            ng-click="aac.onStartDrawCircle()"
+                            title="Draw custom radius">
+                        <i class="md-icon-polygon-circle"></i>
+                    </button>
+                </div>
+            </div>
+        </form>
     </div>
-    <div class="action-group">
-        <div class="form-group">
-            <button type="button"
-                    class="form-control mapExpand"
-                    data-toggle="tooltip"
-                    data-placement="bottom"
-                    ng-click="aac.onStartDrawCircle()"
-                    title="Draw custom radius">
-                <i class="md-icon-polygon-circle"></i>
-            </button>
-        </div>
-    </div>
-</form>
+</div>

--- a/app/scripts/map/cartodb-vis-directive.js
+++ b/app/scripts/map/cartodb-vis-directive.js
@@ -55,6 +55,9 @@
         var mapDomId = 'map';
         var demographicsVisible = false;
         var $popover;
+        var orgLegend;
+        var demographicsLegend;
+        var legends;
 
         initialize();
 
@@ -79,19 +82,20 @@
             $scope.$watch(function () { return ctl.visFullscreen; }, onVisFullscreenChanged);
         }
 
-        function onSublayerChange(sublayer) {
+        function onSublayerChange(sublayer, index) {
             angular.forEach(ctl.sublayers, function (s) {
                 s.hide();
-                //s.legend.set('visible', false);
             });
             demographicsVisible = !!(sublayer);
             if (sublayer) {
                 sublayer.show();
-                // sublayer.legend.set('visible', true);
+                demographicsLegend = new cdb.geo.ui.Legend(ctl.demographicsConfig[index]);
             } else {
+                demographicsLegend = undefined;
                 // Hide the sticky tooltip by clearing block styling...weee this is messy
                 $('div.cartodb-tooltip .tooltip-tracts').parent().css('display', 'none');
             }
+            renderLegends(orgLegend, demographicsLegend);
         }
 
         function onVisReady(vis) {
@@ -99,8 +103,7 @@
             var layers = vis.getLayers();
 
             if (Config.cartodb.legend) {
-                var legend = new cdb.geo.ui.Legend.Category(Config.cartodb.legend);
-                  $('#' + mapDomId + ' .leaflet-container').append(legend.render().el);
+                orgLegend = new cdb.geo.ui.Legend.Category(Config.cartodb.legend);
             }
             // Pretty hacky, but simpler than other options:
             //  If one of the demographics layers are visible, then we want to find the
@@ -137,7 +140,6 @@
                 var demographicsOptions = angular.extend({}, defaultOptions, {});
                 cartodb.createLayer(map, Config.cartodb.demographicVisUrl, demographicsOptions)
                 .addTo(map).done(function (layer) {
-                    $('div.cartodb-legend').filter(':first').css('bottom', '150px');
                     ctl.sublayers = layer.getSubLayers();
                     angular.forEach(ctl.sublayers, function (sublayer) {
                         sublayer.setInteraction(true);
@@ -153,6 +155,9 @@
                     }
                 });
             }
+
+            // Render legend
+            renderLegends(orgLegend, demographicsLegend);
 
             // Force museum points back to the top
             // Always layer one of the main visualization (basemap is layer zero)
@@ -260,6 +265,22 @@
                 .setLatLng(latLng)
                 .setContent(popupHtml[0])
                 .openOn(map);
+        }
+
+        function renderLegends(orgLegend, demographicsLegend) {
+            var legends = [];
+            if (orgLegend) {
+                legends.push(orgLegend);
+            }
+            if (demographicsLegend) {
+                legends.push(demographicsLegend);
+            }
+            var stackedLegend = new cdb.geo.ui.StackedLegend({
+                legends: legends
+            });
+            var $legends = $('.map-container .vis-legends');
+            $legends.empty();
+            $legends.append(stackedLegend.render().el);
         }
 
     }

--- a/app/scripts/map/cartodb-vis-directive.js
+++ b/app/scripts/map/cartodb-vis-directive.js
@@ -32,7 +32,8 @@
     ].join('');
 
     /* ngInject */
-    function VisController($attrs, $log, $compile, $q, $scope, $timeout, Config, OrgCountService) {
+    function VisController($attrs, $log, $compile, $q, $scope, $timeout,
+                           Config, DemographicsConfig, OrgCountService) {
 
         var MAP_SLIDE_TRANSITION_MS = 400;
 
@@ -59,6 +60,7 @@
 
         function initialize() {
             ctl.demographics = !!($scope.$eval($attrs.demographics));
+            ctl.demographicsConfig = DemographicsConfig;
             ctl.drawControl = !!($scope.$eval($attrs.drawControl));
             ctl.filterControl = !!($scope.$eval($attrs.filterControl));
             ctl.visFullscreenClass = $attrs.visFullscreenClass || 'map-expanded';

--- a/app/scripts/map/cartodb-vis-directive.js
+++ b/app/scripts/map/cartodb-vis-directive.js
@@ -149,10 +149,6 @@
                     $scope.$apply();
 
                     layer.on('featureOver', onDemographicsLayerFeatureOver);
-                    // Need to slide demographics control up if both draw/demographics are active
-                    if (ctl.drawControl) {
-                        $('div.vis-layer-selector').css('bottom', '140px');
-                    }
                 });
             }
 

--- a/app/scripts/map/cartodb-vis-directive.js
+++ b/app/scripts/map/cartodb-vis-directive.js
@@ -103,7 +103,7 @@
             var layers = vis.getLayers();
 
             if (Config.cartodb.legend) {
-                orgLegend = new cdb.geo.ui.Legend.Category(Config.cartodb.legend);
+                orgLegend = new cdb.geo.ui.Legend(Config.cartodb.legend);
             }
             // Pretty hacky, but simpler than other options:
             //  If one of the demographics layers are visible, then we want to find the

--- a/app/scripts/map/cartodb-vis-partial.html
+++ b/app/scripts/map/cartodb-vis-partial.html
@@ -16,7 +16,7 @@
                                ng-model="vis.radio"
                                value="{{ $index }}"
                                ng-change="vis.onSublayerChange(sublayer)">
-                               {{ sublayer.legend.get('title') }}
+                               {{ vis.demographicsConfig[$index].title }}
                     </label>
                 </li>
                 <li>

--- a/app/scripts/map/cartodb-vis-partial.html
+++ b/app/scripts/map/cartodb-vis-partial.html
@@ -15,7 +15,7 @@
                         <input type="radio"
                                ng-model="vis.radio"
                                value="{{ $index }}"
-                               ng-change="vis.onSublayerChange(sublayer)">
+                               ng-change="vis.onSublayerChange(sublayer, $index)">
                                {{ vis.demographicsConfig[$index].title }}
                     </label>
                 </li>
@@ -35,5 +35,6 @@
     <div id="vis-popover"></div>
     <div id="map"></div>
     <div class="cartodb-fullscreen"><a ng-click="vis.onFullscreenClicked()"></a></div>
+    <div class="vis-legends"></div>
 </div> <!-- /.map-container -->
 

--- a/app/scripts/map/cartodb-vis-partial.html
+++ b/app/scripts/map/cartodb-vis-partial.html
@@ -1,37 +1,39 @@
 <div class="map-container">
-    <div class="vis-layer-selector"
-         ng-if="vis.sublayers.length"
-         ng-mouseleave="vis.layersVisible = false">
-        <div class="vis-layer-selector-button"
-             ng-class="{ 'visible': vis.layersVisible }"
-             ng-click="vis.layersVisible = !vis.layersVisible">
-            <i class="md-icon-layers"></i><span ng-show="vis.layersVisible">Demographics</span>
+    <div class="vis-controls">
+        <div viz-filter-control ng-if="vis.filterControl"></div>
+        <div class="vis-control vis-layer-selector"
+            ng-class="{ 'visible': vis.layersVisible }"
+            ng-if="vis.sublayers.length">
+            <div class="vis-control-button"
+                ng-click="vis.layersVisible = !vis.layersVisible">
+                <i class="md-icon-layers"></i>
+                <span ng-show="vis.layersVisible">Demographics</span>
+            </div>
+            <div class="vis-control-body"
+                ng-show="vis.layersVisible">
+                <ul>
+                    <li ng-repeat="sublayer in vis.sublayers">
+                        <label>
+                            <input type="radio"
+                                ng-model="vis.radio"
+                                value="{{ $index }}"
+                                ng-change="vis.onSublayerChange(sublayer, $index)">
+                                {{ vis.demographicsConfig[$index].title }}
+                        </label>
+                    </li>
+                    <li>
+                        <label>
+                            <input type="radio"
+                                ng-model="vis.radio"
+                                value="-1"
+                                ng-change="vis.onSublayerChange(null)"> Off
+                        </label>
+                    </li>
+                </ul>
+            </div>
         </div>
-        <div class="vis-layer-selector-body"
-             ng-show="vis.layersVisible">
-            <ul>
-                <li ng-repeat="sublayer in vis.sublayers">
-                    <label>
-                        <input type="radio"
-                               ng-model="vis.radio"
-                               value="{{ $index }}"
-                               ng-change="vis.onSublayerChange(sublayer, $index)">
-                               {{ vis.demographicsConfig[$index].title }}
-                    </label>
-                </li>
-                <li>
-                    <label>
-                        <input type="radio"
-                               ng-model="vis.radio"
-                               value="-1"
-                               ng-change="vis.onSublayerChange(null)"> Off
-                    </label>
-                </li>
-            </ul>
-        </div>
+        <div area-analysis-control ng-if="vis.drawControl"></div>
     </div>
-    <div area-analysis-control class="vis-draw-control" ng-if="vis.drawControl"></div>
-    <div viz-filter-control class="vis-filter-control" ng-if="vis.filterControl"></div>
     <div id="vis-popover"></div>
     <div id="map"></div>
     <div class="cartodb-fullscreen"><a ng-click="vis.onFullscreenClicked()"></a></div>

--- a/app/scripts/map/demographics-config.js
+++ b/app/scripts/map/demographics-config.js
@@ -1,0 +1,37 @@
+(function() {
+    'use strict';
+
+    /**
+     * Configuration for demographics legends
+     * @type {Object}
+     */
+    var config = [{
+        title: 'Median Income ($)',
+        type: 'choropleth',
+        data: [
+            { value: 0 },
+            { value: 130000 },
+            { name: '1', value: '#f7f7f7' },
+            { name: '2', value: '#cccccc' },
+            { name: '3', value: '#969696' },
+            { name: '4', value: '#636363' },
+            { name: '5', value: '#252525' }
+        ]
+    }, {
+        title: 'Poverty Rate (%)',
+        type: 'choropleth',
+        data: [
+            { value: 0 },
+            { value: 74.4 },
+            { name: '1', value: '#f7f7f7' },
+            { name: '2', value: '#cccccc' },
+            { name: '3', value: '#969696' },
+            { name: '4', value: '#636363' },
+            { name: '5', value: '#252525' }
+        ]
+    }];
+
+    angular.module('imls.map')
+    .constant('DemographicsConfig', config);
+
+})();

--- a/app/scripts/map/demographics-config.js
+++ b/app/scripts/map/demographics-config.js
@@ -31,6 +31,32 @@
             { name: '4', value: '#636363' },
             { name: '5', value: '#252525' }
         ]
+    }, {
+        title: 'Percent Children (%)',
+        show_title: true,
+        type: 'choropleth',
+        data: [
+            { value: 0 },
+            { value: 41 },
+            { name: '1', value: '#f7f7f7' },
+            { name: '2', value: '#cccccc' },
+            { name: '3', value: '#969696' },
+            { name: '4', value: '#636363' },
+            { name: '5', value: '#252525' }
+        ]
+    }, {
+        title: 'Percent Adults without HS Diploma (%)',
+        show_title: true,
+        type: 'choropleth',
+        data: [
+            { value: 0 },
+            { value: 100 },
+            { name: '1', value: '#f7f7f7' },
+            { name: '2', value: '#cccccc' },
+            { name: '3', value: '#969696' },
+            { name: '4', value: '#636363' },
+            { name: '5', value: '#252525' }
+        ]
     }];
 
     angular.module('imls.map')

--- a/app/scripts/map/demographics-config.js
+++ b/app/scripts/map/demographics-config.js
@@ -7,6 +7,7 @@
      */
     var config = [{
         title: 'Median Income ($)',
+        show_title: true,
         type: 'choropleth',
         data: [
             { value: 0 },
@@ -19,6 +20,7 @@
         ]
     }, {
         title: 'Poverty Rate (%)',
+        show_title: true,
         type: 'choropleth',
         data: [
             { value: 0 },

--- a/app/scripts/map/filter-control-partial.html
+++ b/app/scripts/map/filter-control-partial.html
@@ -1,6 +1,12 @@
-<p>Organization Type:</p>
-<select
-    ng-change="fc.onFilterOptionChanged()"
-    ng-model="fc.filterValue"
-    ng-options="item as item.name for item in fc.options track by item.name">
-</select>
+<div class="vis-control vis-filter-control" ng-class="{'visible': fc.open}">
+    <div class="vis-control-button" ng-click="fc.open = !fc.open">
+        <i class="md-icon-filter"></i><span ng-show="fc.open">Organization Type</span>
+    </div>
+    <div class="vis-control-body" ng-show="fc.open">
+        <select
+            ng-change="fc.onFilterOptionChanged()"
+            ng-model="fc.filterValue"
+            ng-options="item as item.name for item in fc.options track by item.name">
+        </select>
+    </div>
+</div>

--- a/app/scripts/views/home/home-partial.html
+++ b/app/scripts/views/home/home-partial.html
@@ -43,7 +43,7 @@
         </div>
     </div>
 
-    <cartodb-vis filter-control="true" vis-fullscreen="home.mapExpanded"></cartodb-vis>
+    <cartodb-vis demographics="true" filter-control="true" vis-fullscreen="home.mapExpanded"></cartodb-vis>
 
     <ui-view></ui-view>
 

--- a/app/scripts/views/museum/museum-partial.html
+++ b/app/scripts/views/museum/museum-partial.html
@@ -13,7 +13,8 @@
             </div>
         </div>
     </div>
-    <cartodb-vis draw-control="true"
+    <cartodb-vis demographics="true"
+                 draw-control="true"
                  filter-control="true"
                  vis-fullscreen="museum.mapExpanded"
                  vis-fullscreen-on-toggle="museum.onMapExpanded"></cartodb-vis>

--- a/app/styles/components/_map-tools.scss
+++ b/app/styles/components/_map-tools.scss
@@ -25,70 +25,58 @@
 
 .map-container {
 
-    .vis-draw-control {
-        p {
-            padding-left: 4px;
-        }
-    }
-
-    .vis-layer-selector,
-    .vis-draw-control {
-        bottom: 120px;
-        right: 20px;
-    }
-
-    .vis-filter-control {
-        bottom: 20px;
-        right: 20px;
-    }
-
     div.cartodb-legend-stack {
         bottom: 20px;
         left: 20px;
         right: auto;
     }
 
-    .vis-layer-selector,
-    .vis-draw-control,
-    .vis-filter-control {
-        padding: 10px;
+    .vis-controls {
         position: absolute;
-        font-size: 13px;
-        -webkit-box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
-        -moz-box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
-        box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
-        background: #fff;
-        -webkit-border-radius: 4px;
-        -moz-border-radius: 4px;
-        -ms-border-radius: 4px;
-        -o-border-radius: 4px;
-        border-radius: 4px;
-        border: 1px solid #999;
+        bottom: 20px;
+        right: 20px;
         z-index: 999;
 
-        .visible {
-            font-size: 16px;
-        }
+        .vis-control {
+            padding: 10px;
+            margin-top: 10px;
+            font-size: 13px;
+            -webkit-box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
+            -moz-box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
+            box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
+            background: #fff;
+            -webkit-border-radius: 4px;
+            -moz-border-radius: 4px;
+            -ms-border-radius: 4px;
+            -o-border-radius: 4px;
+            border-radius: 4px;
+            border: 1px solid #999;
+            z-index: 1000;
+            width: 41px;
+            float: right;
+            clear: both;
 
-        .vis-layer-selector-body {
-            margin: 10px 10px 0 10px;
-        }
+            ul {
+                padding: 0;
+                list-style: none;
+            }
 
-        ul {
-            padding: 0;
-            list-style: none;
-        }
-    }
+            &.visible {
+                width: auto;
+            }
 
-    .vis-layer-selector-button {
-        cursor: pointer;
+            .vis-control-button {
+                cursor: pointer;
 
-        &:after {
-            content: 'Add Demographics';
-        }
+                & > span {
+                    font-size: 16px;
+                    margin-left: 5px;
+                }
+            }
 
-        &.visible:after {
-            display: none;
+            .vis-control-body {
+                margin: 10px 10px 0 10px;
+            }
         }
     }
 

--- a/app/styles/components/_map-tools.scss
+++ b/app/styles/components/_map-tools.scss
@@ -21,12 +21,6 @@
     div.cartodb-tiles-loader {
         margin-top: 0;
     }
-
-    div.cartodb-legend {
-        bottom: 40px;
-        left: 20px;
-        right: auto;
-    }
 }
 
 .map-container {
@@ -39,17 +33,19 @@
 
     .vis-layer-selector,
     .vis-draw-control {
-        bottom: 20px;
+        bottom: 120px;
         right: 20px;
     }
 
     .vis-filter-control {
         bottom: 20px;
-        left: 20px;
+        right: 20px;
     }
 
-    .cartodb-legend {
-        bottom: 120px !important;
+    div.cartodb-legend-stack {
+        bottom: 20px;
+        left: 20px;
+        right: auto;
     }
 
     .vis-layer-selector,


### PR DESCRIPTION
## Overview

Brings back the demographics layers. Update visualization in Carto to include the four requested layers, including copying data from the acs table for the last item (% Adults w/o HS Diploma).

Implemented map controls suggested in #27 

## Demo

![screen shot 2017-11-17 at 15 17 10](https://user-images.githubusercontent.com/1818302/32967140-7f7e6100-cbaa-11e7-9489-804d818fe502.png)
![screen shot 2017-11-17 at 15 17 23](https://user-images.githubusercontent.com/1818302/32967142-81711110-cbaa-11e7-9989-18fc74313454.png)
![screen shot 2017-11-17 at 15 17 36](https://user-images.githubusercontent.com/1818302/32967143-833c0e3c-cbaa-11e7-9316-b0356ced35ac.png)

## Notes

New map controls interactivity could use a styling pass. My CSS is pretty rusty.

The hover control doesn't get the right styling from Carto. Also could use a styling pass.

Not sure how to handle the double hover boxes that sometimes stomp on each other depending on where on the map you're hovering.

@designmatty there might be some merge conflicts between this and #30. I'll try to clean up as best I can once that's merged.

## Testing

Copy new config items in the diff below to your config.js to ensure legend and demographics hover interactivity works as expected.

Then click the demographics layer control to open it, and check out the individual layers.

Closes #27 
