### PR TITLE
Update radius search options on detail view

### DIFF
--- a/app/scripts/map/area-analysis-control-directive.js
+++ b/app/scripts/map/area-analysis-control-directive.js
@@ -35,20 +35,23 @@
             // A 'custom' option is dynamically added to this list whenever
             //  the user draws a custom polygon
             ctl.acsRadiusOptions = [{
+                value: ONE_MILE_IN_M * 0.25,
+                label: '0.25 Mile Radius'
+            }, {
+                value: ONE_MILE_IN_M * 0.5,
+                label: '0.5 Mile Radius'
+            }, {
                 value: ONE_MILE_IN_M,
                 label: '1 Mile Radius'
             }, {
-                value: ONE_MILE_IN_M * 3,
-                label: '3 Mile Radius'
+                value: ONE_MILE_IN_M * 2.5,
+                label: '2.5 Mile Radius'
             }, {
                 value: ONE_MILE_IN_M * 5,
                 label: '5 Mile Radius'
-            }, {
-                value: ONE_MILE_IN_M * 25,
-                label: '25 Mile Radius'
             }];
-            ctl.acsRadius = ctl.acsRadiusOptions[0].value;
-            setArea(ctl.acsRadius);
+            ctl.acsRadius = ctl.acsRadiusOptions[1].value;
+            setArea(Area.circle(ctl.acsRadius));
 
             ctl._onRadiusChanged = _onRadiusChanged;
             ctl.onStartDrawPolygon = onStartDrawPolygon;

--- a/app/scripts/views/museum/museum-controller.js
+++ b/app/scripts/views/museum/museum-controller.js
@@ -11,6 +11,7 @@
 
         var LOAD_TIMEOUT_MS = 300;
         var ONE_MILE_IN_M = 1609.344;
+        var DEFAULT_RADIUS = ONE_MILE_IN_M * 0.5;
 
         var vis = null;
         var map = null;
@@ -85,7 +86,7 @@
         }
 
         function onRadiusChanged(event, radius) {
-            radius = radius || ONE_MILE_IN_M;
+            radius = radius || DEFAULT_RADIUS;
             if (!ctl.museum) { return; }
             var center = L.latLng(ctl.museum.latitude, ctl.museum.longitude);
             // Initialize charts with data in a 1 mi radius


### PR DESCRIPTION
## Overview

Updates the radius dropdown options on the draw control.

Fixes a bug where the initial display area could be set to the radius instead. I do not believe this resolves the error mentioned by @jcahail in #28.

I was unable to reproduce any errors with the draw control. If you are able to do so in testing, let me know.

## Demo

![screen shot 2017-11-20 at 13 32 14](https://user-images.githubusercontent.com/1818302/33034872-3e383b0e-cdf7-11e7-85e7-19a09a270ecb.png)

## Testing

Use the draw control. All options should continue to work, with updated defaults.

Closes #28 