### PR TITLE
Replace site copy on static pages

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -2,7 +2,7 @@
 <html class="no-js">
   <head>
     <meta charset="utf-8">
-    <title>MuseumStat: Connecting Museums and Communities</title>
+    <title>ImpactView: Philly</title>
     <meta name="description" content="">
     <link rel="stylesheet" href="styles/fonts/fontello/css/museum-db.css" />
     <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html class="no-js">
   <head>
     <meta charset="utf-8">
-    <title>MuseumStat: Connecting Museums and Communities</title>
+    <title>ImpactView: Philly</title>
     <meta name="description" content="">
     <link rel="stylesheet" href="styles/fonts/fontello/css/museum-db.css" />
     <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />

--- a/app/scripts/views/about/about-partial.html
+++ b/app/scripts/views/about/about-partial.html
@@ -20,31 +20,21 @@
                 <div class="col-xs-8 col-xs-push-2">
                     <div class="content-title text-center">
                         <img class="museum-logo" src="/images/impact-view-logo.png">
-                        <h2>About Museum<b>Stat</b></h2>
+                        <h2>About ImpactView</b></h2>
                     </div>
-                    <p>MuseumStat is a robust online resource to support museums, communities, and researchers in gaining insights into the reach of museums and the communities they serve. MuseumStat contains information on about 30,000 organizations in the Institute of Museum and Library Services’ <a href="https://data.imls.gov/browse?limitTo=datasets&sortBy=newest&tags=mudf" target="_blank">Museum Universe Data File</a> (MUDF). The museum data are combined with community metrics on every census tract in the United States. MuseumStat is built on a geographical information system (GIS) platform that is designed to be intuitive and useful to a wide range of users and will continue to grow in its scope of features and information.</p>
+                    <p>ImpactView Philadelphia is a powerful online resource to support a better understanding of Philadelphia’s nonprofit ecosystem. ImpactView Philadelphia helps nonprofit organizations, philanthropies, and community leaders identify needs and opportunities, explore areas of collaboration, and develop programs and services based on measures of community health.</p>
+
+                    <p>ImpactView Philadelphia visualizes important data on nonprofit organizations combined with individual and household data in an intuitive and user-friendly format.</p>
 
                     <div class="content-title">
-                        <h3>For Museums</h3>
+                        <h3>About the data</h3>
                     </div>
-                    <p>MuseumStat provides museum leaders with information to help in planning  their programming and outreach activities, improve their casemaking to grantmakers, and generate data-informed analyses to enhance their community impact.</p>
+                    <p>ImpactView Philadelphia uses publicly available data on nonprofit organizations through the Internal Revenue Service’s new machine-readable data portal and Business Master File comprising more than 2,300 nonprofit organizations within the city limits. This data is combined with the most recent American Community Survey data released by the U.S. Census Bureau, which is updated annually and provides detailed information at the census tract level. These data sources are combined into a mapping and visualization interface that is free, public, and easy to use.</p>
 
                     <div class="content-title">
-                        <h3>For Communities</h3>
+                        <h3>About the Creators</h3>
                     </div>
-                    <p>MuseumStat provides community leaders with important indicators of community health and well-being, easily accessible through maps, charts, and graphs. A wide range of museums are identified as community assets and potential partners for programs and services.</p>
-
-                    <div class="content-title">
-                        <h3>For Researchers</h3>
-                    </div>
-                    <p>MuseumStat provides researchers, advocates, and policymakers with important data to understand the potential reach of museums in communities. Data is visualized on-screen and provided for download to allow for the widest possible use and analyses.</p>
-
-                    <div class="content-title">
-                        <h3>About the Data</h3>
-                    </div>
-                    <p>MuseumStat uses two key types of data, MUDF and the U.S. Census Bureau’s <a href="https://www.census.gov/programs-surveys/acs/" target="_blank">American Community Survey</a> (ACS).</p>
-                    <p>MUDF integrates data from several sources, including IMLS administrative records of <a href="https://data.imls.gov/browse%3Ftags=discretionary%26sortBy=newest" target="_blank">discretionary grant recipients</a> and IRS records of <a href="https://www.irs.gov/charities-non-profits/exempt-organizations-select-check" target="_blank">tax-exempt organizations</a>, among other sources. There are inherent limitations in the use of such data and we cannot attest to its overall accuracy and quality. We encourage you to learn more about how <a href="https://www.imls.gov/research-evaluation/data-collection/museum-universe-data-file" target="_blank">IMLS created MUDF</a>, its coverage, and maintenance. We also recommend you develop strategies for addressing these limitations.</p>
-                    <p>The ACS is an ongoing statistical survey of the U.S. Census Bureau that gathers in-depth information on individuals and households throughout the country. MuseumStat uses the ACS 5-year estimates from 2010-2014, which allows for analysis down to the census tract level.</p>
+                    <p>ImpactView Philadelphia is a project of Drexel University’s graduate Arts Administration program. The project is led by professor and research director Neville Vakharia. ImpactView Philadelphia was supported by a Digital Impact Grant from the Stanford Center for Philanthropy and Civil Society, funded by the Bill and Melinda Gates Foundation. Software development by <a href="https://www.azavea.com">Azavea</a>.</p>
                 </div>
             </div>
         </div> <!-- /.container-fluid -->

--- a/app/scripts/views/contact/contact-partial.html
+++ b/app/scripts/views/contact/contact-partial.html
@@ -23,11 +23,11 @@
                         <h2>Contact Us</h2>
                         <hr>
                     </div>
-                    <p>MuseumStat is a robust tool created to understand the reach of museums in communities in the United States. We want to ensure that MuseumStat meets your needs and provides you with valuable information.</p>
-                    <p>Please <a href="mailto:research@imls.gov?subject=MUDF updates from MuseumStat">contact IMLS</a> to share any corrections, additions, or deletions to the organizations listed in MUDF.</p>
-                    <p>MuseumStat was developed through a cooperative agreement between Drexel University and the Institute of Museum and Library Services. Professor Neville K. Vakharia of Drexel University’s graduate arts administration program is the principal investigator.</p>
+                    <p>ImpactView Philadelphia is a powerful tool created to serve the nonprofit and philanthropic sectors within Philadelphia. We rely on your feedback to make improvements and enhancements that will benefit users.</p>
+                    <p>Contact Us to share your feedback, questions, or comments. If you are interested in seeing ImpactView in another city or region, we would like to hear from you.
+
                     <hr>
-                    <a href="mailto:info@museumstat.org" class="btn btn-primary">Contact Us</a>
+                    <a href="mailto:info@impactview.org" class="btn btn-primary">Contact Us</a>
                 </div>
             </div>
         </div> <!-- /.container-fluid -->

--- a/app/scripts/views/footer/footer-partial.html
+++ b/app/scripts/views/footer/footer-partial.html
@@ -2,26 +2,18 @@
     <div class="footer-section-secondary">
         <div class="container-fluid">
             <div class="row">
-                <div class="col-xs-3">
+                <div class="col-xs-4">
                     <h3 class="white">A cooperative research project of:</h3>
+                </div>
+                <div class="col-xs-4">
                     <a class="logo" href="http://www.imls.gov" target="_blank">
                         <img srcset="/images/2x/logo@2x.png 2x" src="/images/logo.png">
                     </a>
+                </div>
+                <div class="col-xs-4">
                     <a class="logo" href="http://drexel.edu/westphal/graduate/AADM/" target="_blank">
                         <img srcset="/images/2x/westphal-logo@2x.png 2x" src="/images/westphal-logo.png" >
                     </a>
-                </div>
-                <div class="col-xs-3">
-                    <a ui-sref="about"><h3>About</h3></a>
-                    <p>MuseumStat is a powerful online resource to support museums, communities, and researchers in gaining useful insights into the scope and reach of museums and the communities they serve. <a ui-sref="about">More...</a></p>
-                </div>
-                <div class="col-xs-3">
-                    <a ui-sref="contact"><h3>Contact</h3></a>
-                    <p>We want to ensure that MuseumStat meets your needs and provides you with valuable information. Learn more and let us know how we can help. <a ui-sref="contact">More...</a></p>
-                </div>
-                <div class="col-xs-3">
-                    <a href="http://data.imls.gov" target="_blank"><h3>Full Dataset</h3></a>
-                    <p>The entire dataset contained in the Museum Universe Data File and other useful datasets can be downloaded for more advanced research and analysis. Access the data and other resources <a href="http://data.imls.gov" target="_blank">here</a>.</p>
                 </div>
             </div>
         </div> <!-- /.container-fluid -->

--- a/app/scripts/views/help/help-partial.html
+++ b/app/scripts/views/help/help-partial.html
@@ -23,30 +23,27 @@
                         <h2>Getting Started</h2>
                         <hr>
                     </div>
-                    <p>MuseumStat is designed to be an intuitive yet powerful tool to provide important information on museums and communities. There are many ways to use MuseumStat to inform decision-making, understand community needs, and make a case for support. If you need any assistance using MuseumStat or would like to share feedback, please contact us at <a href="mailto:info@museumstat.org">info@museumstat.org</a>.</p>
+                    <p>ImpactView Philadelphia uses an intuitive interface, combining maps, data visualization, and search functionality.</p>
 
                     <div class="content-title">
-                        <h3>Search for Museums or Communities</h3>
+                        <h3>Search for Organizations</h3>
                     </div>
-                    <p>Start by using the search bar to enter the name of a specific museum or enter an address, city, or zip code.</p>
+                    <p>Explore the map by searching by organization, zip code, or address. If you enter a zip code or address the map will show that location with a list of organizations within that area. Select an organization by clicking on it in the map or from the list below for more details. </p>
 
                     <div class="content-title">
-                        <h3>Analyze by Museum</h3>
+                        <h3>Analyzing Organizations</h3>
                     </div>
-                    <p>Selecting a specific museum from the search bar will display a page for the museum selected and show its location on a map along with surrounding museums. A default radius of 1 mile is shown around the museum selected.</p>
-                    <p>Below the map are important data on individuals and households in the area selected along with regional and statewide comparisons of museums. View data through the three tabs shown. Move your mouse over the charts to get more details of the data displayed.</p>
-                    <p>Adjust the analysis area using the menu or by drawing a custom radius or shape. The data below will automatically update based on the area you selected.</p>
-                    <p>Use the “Add Demographics” icon on the map to show important demographic measures on the map. Move your mouse over this layer to see the data on the demographic option selected.</p>
-                    <p>Create a useful report of this map and data by selecting “Print This Report.” The report can be printed or saved as a PDF.</p>
-                    <p>If you want to submit any updates to the information on a museum, select “Submit Museum Update” to contact us.</p>
+                    <p>Explore the map by searching by organization, zip code, or address. If you enter a zip code or address the map will show that location with a list of organizations within that area. Select an organization by clicking on it in the map or from the list below for more details. </p>
 
-                    <div class="content-title">
-                        <h3>Analyze by Community</h3>
-                    </div>
-                    <p>Selecting a specific address, city or zip code from the search bar will display the region selected and show its location on a map along with surrounding museums.</p>
-                    <p>Below the map is a list of the surrounding museums that appear on the map.</p>
-                    <p>Use the “View &amp; Analyze” button next to a specific museum to get details of that museum along with important data on the surrounding community. See “Analyze by Museum” above for details.</p>
-                    <p>From the list of museums, use the “Download Museum Info” link to download a file of all the museums listed along with relevant data on each museum.</p>
+                    <p>Once you have selected an organization, the map will show that organization on the map with a data visualization below comprising important measures of households and individuals using a default radius of 0.5 miles surrounding the organization.</p>
+
+                    <p>Use the <i class="md-icon-polygon-draw"></i> tool to change the radius for which the data is visualized.</p>
+
+                    <p>Use the <i class="md-icon-filter"></i> tool to filter by the type of nonprofit organization</p>
+
+                    <p>Use the <i class="md-icon-layers"></i> tool to view important demographics on the map.</p>
+
+                    <p>Use the <i class="md-icon-resize-full"></i> tool to maximize the view of the map for improved interaction.</p>
                 </div>
             </div>
         </div> <!-- /.container-fluid -->


### PR DESCRIPTION
## Overview

Replace site text on About, Getting Started and Contact pages.

## Testing

Navigate to each of the pages noted above, and ensure text matches the docx file provided by Neville in #32 

Closes #10 