### PR TITLE
Tweak URL route

### DIFF
--- a/app/scripts/map/cartodb-vis-directive.js
+++ b/app/scripts/map/cartodb-vis-directive.js
@@ -16,7 +16,7 @@
         '<div class="popup-content">',
         '<div class="popup-content-row" ng-repeat="row in rows">',
         '<span class="org-type" style="background-color: {{ row.orgTypeColor }};"></span>',
-        '<a href="/#/museum/{{row.ein_new}}/">{{ row.organization_new }}</a>',
+        '<a href="/#/organization/{{row.ein_new}}/">{{ row.organization_new }}</a>',
         '</div>',
         '</div>',
         '</div>',

--- a/app/scripts/views/museum/module.js
+++ b/app/scripts/views/museum/module.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function StateConfig($stateProvider) {
         $stateProvider.state('museum', {
-            url: '/museum/:museum/',
+            url: '/organization/:museum/',
             templateUrl: 'scripts/views/museum/museum-partial.html',
             controller: 'MuseumController',
             controllerAs: 'museum'


### PR DESCRIPTION
## Overview

Use a more generic "organization" route name to replace "museum" since we're not looking at museums anymore. Minor QoL update.

## Demo

![screen shot 2017-11-20 at 14 26 12](https://user-images.githubusercontent.com/1818302/33037261-efede1c6-cdfe-11e7-8465-202362522ba4.png)

## Testing

App should continue to properly route before, via:
- On map popups
- "View and Analyze" buttons on search results page
- "Back" arrow on org detail view
