### PR TITLE
Miscellaneous final improvements

### DIFF
--- a/app/scripts/map/area-analysis-control-partial.html
+++ b/app/scripts/map/area-analysis-control-partial.html
@@ -1,5 +1,9 @@
 <div class="vis-control vis-draw-control" ng-class="{'visible': aac.open}">
-    <div class="vis-control-button" ng-click="aac.open = !aac.open">
+    <div class="vis-control-button"
+         ng-click="aac.open = !aac.open"
+         uib-tooltip="Change Analysis Area"
+         tooltip-placement="left"
+         tooltip-enable="!aac.open">
         <i class="md-icon-polygon-draw"></i><span ng-show="aac.open">Analysis Area: {{ aac.area }} sq. miles</span>
     </div>
     <div class="vis-control-body" ng-show="aac.open">

--- a/app/scripts/map/cartodb-vis-partial.html
+++ b/app/scripts/map/cartodb-vis-partial.html
@@ -5,7 +5,10 @@
             ng-class="{ 'visible': vis.layersVisible }"
             ng-if="vis.sublayers.length">
             <div class="vis-control-button"
-                ng-click="vis.layersVisible = !vis.layersVisible">
+                ng-click="vis.layersVisible = !vis.layersVisible"
+                uib-tooltip="Apply Demographic Layers"
+                tooltip-placement="left"
+                tooltip-enable="!vis.layersVisible">
                 <i class="md-icon-layers"></i>
                 <span ng-show="vis.layersVisible">Demographics</span>
             </div>
@@ -36,7 +39,6 @@
     </div>
     <div id="vis-popover"></div>
     <div id="map"></div>
-    <div class="cartodb-fullscreen"><a ng-click="vis.onFullscreenClicked()"></a></div>
+    <div class="cartodb-fullscreen" uib-tooltip="Expand map view" tooltip-placement="left"><a ng-click="vis.onFullscreenClicked()"></a></div>
     <div class="vis-legends"></div>
 </div> <!-- /.map-container -->
-

--- a/app/scripts/map/filter-control-partial.html
+++ b/app/scripts/map/filter-control-partial.html
@@ -1,5 +1,9 @@
 <div class="vis-control vis-filter-control" ng-class="{'visible': fc.open}">
-    <div class="vis-control-button" ng-click="fc.open = !fc.open">
+    <div class="vis-control-button"
+         ng-click="fc.open = !fc.open"
+         uib-tooltip="Filter by Organization Type"
+         tooltip-placement="left"
+         tooltip-enable="!fc.open">
         <i class="md-icon-filter"></i><span ng-show="fc.open">Organization Type</span>
     </div>
     <div class="vis-control-body" ng-show="fc.open">

--- a/app/scripts/views/home/search-partial.html
+++ b/app/scripts/views/home/search-partial.html
@@ -29,7 +29,7 @@
         </div>
         <div class="container-fluid" ng-if="home.pageState === home.states.ERROR">
             <img class="museum-icon" src="/images/museum-icon.svg">
-            <h3>Sorry, your search has returned no museums. <br> Please refine your search.</h3>
+            <h3>Sorry, your search has returned no organizations. <br> Please refine your search.</h3>
         </div>
         <table st-table="search.safeList" st-safe-src="search.list" ng-if="home.pageState === home.states.LIST" class="table table-striped">
             <thead>

--- a/app/scripts/views/home/search-partial.html
+++ b/app/scripts/views/home/search-partial.html
@@ -15,7 +15,7 @@
                             role="menu"
                             aria-labelledby="dropdownMenu1">
                             <li role="menuitem"><a ng-click="search.onDownloadRowClicked()">Search Results</a></li>
-                            <li role="menuitem"><a href="https://docs.google.com/spreadsheets/d/1FvaelATp9skACO8jYE8UJX4xWoZpYgmx042rnzPfPZw/edit" target="_blank">Download Organization Data</a></li>
+                            <li role="menuitem"><a href="https://docs.google.com/spreadsheets/d/1FvaelATp9skACO8jYE8UJX4xWoZpYgmx042rnzPfPZw/edit" target="_blank">All Organizations</a></li>
                         </ul>
                     </div>
                 </div>

--- a/app/scripts/views/museum/museum-controller.js
+++ b/app/scripts/views/museum/museum-controller.js
@@ -43,6 +43,12 @@
             $scope.$on('imls:area-analysis-control:draw:complete', onDrawCreated);
 
             resize($scope).call(ACSGraphs.updateCharts);
+
+            // Sometimes this view doesn't start at the top of the window when navigated to
+            // It's unclear what triggers cause this, as one user reliably reproduces on MacOS
+            // plus Chrome, but another with the same setup could not, but was able to intermittently
+            // reproduce in Safari.
+            $window.scrollTo(0, 0);
         }
 
         function onVisReady(event, newVis, newMap) {

--- a/app/styles/layout/_footer.scss
+++ b/app/styles/layout/_footer.scss
@@ -48,7 +48,7 @@ footer {
 
 	h3 {
 		margin-top: 30px;
-        font-size: 1.8rem;
+        font-size: 1.2rem;
 	}
 
     h3.white {

--- a/app/styles/pages/_home.scss
+++ b/app/styles/pages/_home.scss
@@ -26,7 +26,7 @@
         width: 150px;
 
         + h3 {
-            color: $white;
+            color: $base;
         }
     }
 


### PR DESCRIPTION
## Demo

#### Rounded demographics layers

![screen shot 2018-01-24 at 10 46 43 am](https://user-images.githubusercontent.com/1818302/35341611-0f764894-00f4-11e8-937a-65688df30db7.png)
![screen shot 2018-01-24 at 10 46 38 am](https://user-images.githubusercontent.com/1818302/35341613-0f7e1ac4-00f4-11e8-9873-160a6a191ffa.png)

#### Tooltips

![screen shot 2018-01-24 at 10 47 00 am](https://user-images.githubusercontent.com/1818302/35341633-19da28d2-00f4-11e8-9f26-f2c7c28de0ce.png)
![screen shot 2018-01-24 at 10 46 55 am](https://user-images.githubusercontent.com/1818302/35341634-19e42a9e-00f4-11e8-8d9c-b59eb664b934.png)

#### Smaller footer text

![screen shot 2018-01-24 at 10 47 37 am](https://user-images.githubusercontent.com/1818302/35341659-2eac9ccc-00f4-11e8-9343-4df641d92b07.png)

#### Visible no results text

![screen shot 2018-01-24 at 10 47 30 am](https://user-images.githubusercontent.com/1818302/35341656-2a661c42-00f4-11e8-9349-60505bac5a27.png)

## Notes

Also attempts to fix an issue in https://github.com/ImpactView/impact-view-philly/commit/50adf10f2ef345915e95d6b4b954a84182ac00ca with scrolling where a user on MacOS 10.12 + latest Chrome clicked on a "View & Analyze" link that required scrolling down on the search page, which took them to the detail page and the detail page wasn't reset to the top of the page. I was only able to reproduce this on MacOS on latest Safari (not on Chrome). We'll have to address this further later if it continues to be a problem.
